### PR TITLE
sepration for the logic of local_modei n the config files

### DIFF
--- a/.traceroot-config-local.yaml
+++ b/.traceroot-config-local.yaml
@@ -1,0 +1,5 @@
+local_mode: true
+service_name: 'sdk-example-service'
+github_owner: 'traceroot-ai'
+github_repo_name: 'traceroot-sdk'
+github_commit_hash: 'main'

--- a/.traceroot-config.yaml
+++ b/.traceroot-config.yaml
@@ -1,5 +1,5 @@
-local_mode: true
-service_name: "example"
-github_owner: "traceroot-ai"
-github_repo_name: "traceroot-examples"
-github_commit_hash: "main"
+token: 'traceroot-5724dd0ee3574060b7d0f3730694f44*'
+service_name: 'example'
+github_owner: 'traceroot-ai'
+github_repo_name: 'traceroot-examples'
+github_commit_hash: 'main'


### PR DESCRIPTION
## 🐛 Fix: Remove `local_mode` from `.traceroot-config.yaml`

### **Summary**
This PR addresses an issue where `local_mode` was incorrectly included in `.traceroot-config.yaml`.  
When `local_mode: true`, traces are only stored locally in Jaeger and are not pushed to Traceroot Cloud, leading to confusion when checking [test.traceroot.ai](https://test.traceroot.ai).

### **Changes Made**
- Removed `local_mode` from `.traceroot-config.yaml`.
- Created a separate `.traceroot-config-local.yaml` for local Jaeger testing.
- Updated README documentation with the correct config separation.

### **Benefits**
- Ensures `.traceroot-config.yaml` is always cloud-ready.
- Developers can still run locally using `.traceroot-config-local.yaml`.
- Avoids confusion and prevents missing traces in Traceroot Cloud.

### **Notes**
It might be useful to add `.traceroot-config-local.yaml` to `.gitignore` to prevent accidental commits.

---

✅ fixes #115
